### PR TITLE
Fix Linux build (OpenAL fail)

### DIFF
--- a/genie/openal.lua
+++ b/genie/openal.lua
@@ -31,6 +31,7 @@ project "openal"
 		buildoptions {
 			"-O2",
 			"-fomit-frame-pointer",
+			"-msse2"
 		}
 
 	configuration { "vs*" }
@@ -77,6 +78,7 @@ project "openal"
 			"-fPIC",
 			"-fvisibility=hidden",
 			"-pthread",
+			"-msse2"
 		}
 		includedirs {
 			AL_DIR .. "OpenAL32/config_linux",

--- a/genie/openal.lua
+++ b/genie/openal.lua
@@ -31,7 +31,6 @@ project "openal"
 		buildoptions {
 			"-O2",
 			"-fomit-frame-pointer",
-			"-msse2"
 		}
 
 	configuration { "vs*" }


### PR DESCRIPTION
**Description**:
Build process fails while compiling OpenAL.

**Errors**:
../../../third/openal/Alc/mixer_sse2.c:33:19: warning: SSE vector return without SSE enabled changes the ABI [-Wpsabi]
/usr/lib/gcc/i686-linux-gnu/4.9/include/emmintrin.h:633:1: error: inlining failed in call to always_inline ‘_mm_set1_epi32’: target specific option mismatch
/usr/lib/gcc/i686-linux-gnu/4.9/include/xmmintrin.h:889:1: error: inlining failed in call to always_inline ‘_mm_set1_ps’: target specific option mismatch
/usr/lib/gcc/i686-linux-gnu/4.9/include/emmintrin.h:633:1: error: inlining failed in call to always_inline ‘_mm_set1_epi32’: target specific option mismatch
...

**Specs**:
- CPU: Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
- GPU: Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics Controller
- OS: Lubuntu (ubuntu 14.04 LTS)
- GCC v: 4.9.0
